### PR TITLE
emBO++: channel moved to nerd-force1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [C++OnSea](https://www.youtube.com/channel/UCAczr0j6ZuiVaiGFZ4qxApw) ([@cpponsea](https://twitter.com/cpponsea)) [[website](https://cpponsea.uk/)]
 - [Code::Dive](https://www.youtube.com/channel/UCU0Rt8VHO5-YNQXwIjkf-1g/videos) ([@code_dive_pl](https://twitter.com/code_dive_pl)) [[website](http://www.codedive.pl)]
 - [Code Europe](https://www.youtube.com/channel/UChdVVEAilVHULlycMbqRpdg/) ([@code_europe](https://twitter.com/code_europe)) [[website](https://www.codeeurope.pl/)] (different programming languages)
-- [emBO++](https://www.youtube.com/channel/UCg2JbpJ-PGdFUEZEiNr0GWg) ([@emBO++](https://twitter.com/emboconference)) [[website](https://www.embo.io)]
+- [emBO++](https://www.youtube.com/c/nerdforce1) ([@emBO++](https://twitter.com/emboconference)) [[website](https://www.embo.io)]
 - [Meeting CPP]( https://www.youtube.com/user/MeetingCPP) ([@meetingcpp](https://twitter.com/meetingcpp)) [[website](https://meetingcpp.com/)] 
 - [NDC Conferences](https://www.youtube.com/channel/UCTdw38Cw6jcm0atBPA39a0Q/) ([@NDC_Conferences](https://twitter.com/ndc_conferences)) [[website](http://ndcconferences.com/)] (different programming languages)
 - [Pacific++](https://www.youtube.com/channel/UCrRR5mU5aqvtZAuEGYfdTjw) ([@pacificplusplus](https://twitter.com/pacificplusplus)) [[website](https://pacificplusplus.com/)] 


### PR DESCRIPTION
Updated emBO++ channel link.
It was moved to new location https://www.youtube.com/c/nerdforce1